### PR TITLE
added `lxml` to `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ KalturaApiClient
 pysftp
 pandas
 tqdm
+lxml


### PR DESCRIPTION
Recent builds of the admin app wouldn't run in new ROSA environment.  Python program would exit with an error message about `lxml`, needed by `KalturaApiClient`.  Reproduced the problem in local environment.  Adding `lxml` to `requirements.txt` resolved the problem.  Not sure why `KalturaApiClient` didn't install that dependency itself.